### PR TITLE
patch(hmr): use hostname for WS instantiation

### DIFF
--- a/src/builtins/hmr-runtime.js
+++ b/src/builtins/hmr-runtime.js
@@ -16,7 +16,7 @@ function Module(config) {
 module.bundle.Module = Module;
 
 if (!module.bundle.parent && typeof WebSocket !== 'undefined') {
-  var ws = new WebSocket('ws://localhost:{{HMR_PORT}}/');
+  var ws = new WebSocket('ws://' + window.location.hostname + ':{{HMR_PORT}}/');
   ws.onmessage = function(event) {
     var data = JSON.parse(event.data);
 


### PR DESCRIPTION
Instead window.location.hostname of localhost for websockets, allowing users to accessing the parcel HMR by the remote IP/domain works.